### PR TITLE
Keep scope when calling haxe cli from haxelib run

### DIFF
--- a/src/haxeshim/HaxeInstallation.hx
+++ b/src/haxeshim/HaxeInstallation.hx
@@ -4,19 +4,21 @@ class HaxeInstallation {
   static var EXT = if (Os.IS_WINDOWS) '.exe' else '';  
   
   public var path(default, null):String;
+  public var scope(default, null):String;
   public var stdLib(default, null):String;
   public var compiler(default, null):String;
   public var haxelib(default, null):String;
   public var version(default, null):String;
   public var haxelibRepo(default, null):String;
   
-  public function new(path:String, version:String, haxelibRepo:String) {
+  public function new(path:String, version:String, haxelibRepo:String, scope:String) {
     this.path = path;
     this.version = version;
     this.compiler = '$path/haxe$EXT';
     this.haxelib = '$path/haxelib$EXT';
     this.stdLib = '$path/std';
     this.haxelibRepo = haxelibRepo;
+    this.scope = scope;
   }
   
   public function env():Env {
@@ -25,6 +27,7 @@ class HaxeInstallation {
       HAXEPATH: path,
       HAXELIB_PATH: haxelibRepo,
       HAXE_VERSION: version,
+      SCOPE_PATH: scope
     }
 
     return ret.mergeInto(Neko.ENV);

--- a/src/haxeshim/HaxelibCli.hx
+++ b/src/haxeshim/HaxelibCli.hx
@@ -92,7 +92,10 @@ class HaxelibCli {
     }
   }
 
-  static function main() 
-    new HaxelibCli(Scope.seek()).dispatch(Sys.args());
+  static function main() {
+    new HaxelibCli(Scope.seek({
+      cwd: Sys.getEnv('SCOPE_PATH')
+    })).dispatch(Sys.args());
+  }
   
 }

--- a/src/haxeshim/Scope.hx
+++ b/src/haxeshim/Scope.hx
@@ -159,12 +159,12 @@ class Scope {
     return 
       switch path(version) {
         case Some(path):
-          new HaxeInstallation(path, version, haxelibRepo);
+          new HaxeInstallation(path, version, haxelibRepo, scopeDir);
         case None:
-          new HaxeInstallation('$versionDir/$version', version, haxelibRepo);
+          new HaxeInstallation('$versionDir/$version', version, haxelibRepo, scopeDir);
       }
   
-  function resolveThroughHaxelib(libs:Array<String>) 
+  function resolveThroughHaxelib(libs:Array<String>)
     return 
       switch Exec.eval(haxeInstallation.haxelib, cwd, ['path'].concat(libs), haxeInstallation.env()) {
         case Success({ status: 0, stdout: stdout }):           
@@ -278,7 +278,7 @@ class Scope {
   static public function seek(?options:SeekingOptions) {
     if (options == null)
       options = {};
-      
+    
     var cwd = switch options.cwd {
       case null: Sys.getCwd();
       case v: v;
@@ -288,14 +288,14 @@ class Scope {
       case null: cwd;
       case v: v;
     }
-    
+
     var haxeshimRoot = switch options.haxeshimRoot {
       case null: DEFAULT_ROOT;
       case v: v;
     }
     
     var make = Scope.new.bind(haxeshimRoot, _, _, cwd);
-        
+
     var ret = switch Fs.findNearest(CONFIG_FILE, startLookingIn.absolutePath()) {
       case Some(v): make(false, v.directory());
       case None: make(true, haxeshimRoot);


### PR DESCRIPTION
Basically the issue is with some `haxelib run` command that call other haxe command (for example: `lime rebuild mac`), since the cwd would be inside the repo directory the scope then become the global one if no `.haxerc` file is present in the repo, so you get errors like "no haxelib named lime installed" from `haxelib path`.

This keeps the scope intact from the first `haxelib run` using an environment variable. 

Perhaps not the best way of handling this particular issue, so feel free to close it but it did fix all of my issues from calling OpenFL's CLI using Lix (only way to fix it otherwise is to install it globally which kind of defeats the purpose). 
