### PR TITLE
Work around for lix-pm/lix.client#44

### DIFF
--- a/src/haxeshim/Resolver.hx
+++ b/src/haxeshim/Resolver.hx
@@ -186,7 +186,13 @@ class Resolver {
 
     var i = 0,
         max = args.length,
-        args = [for (a in args) interpolate(a, defaults)];
+        args = args.copy();
+
+    for (a in 0 ... args.length) {
+      // Work around completion server failing on string interpolation (lix-pm/lix.client#44)
+      if (args[a] == '--display') break;
+      args[a] = interpolate(args[a], defaults);
+    }
 
     function next()
       return


### PR DESCRIPTION
This not so very elegant solution stops interpolation of arguments after the `--display` argument comes through. This effectively solves completion problems for me but doesn't really solve the underlying issue.