### PR TITLE
Add docs for Config and LibResolution

### DIFF
--- a/src/haxeshim/Config.hx
+++ b/src/haxeshim/Config.hx
@@ -1,6 +1,20 @@
 package haxeshim;
 
 typedef Config = {
+  /**
+    Which Haxe version to use. Allowed values are:
+      - SemVer version numbers such as `3.4.7` and `4.0.0-rc.2`
+      - several convenience "constants":
+        - `"latest"`: the latest release of Haxe (including preview releases)
+        - `"stable"`: the latest _stable_ release of Haxe
+        - `"nightly"` / `"edge"`: the latest nightly build of Haxe
+      - commit hashes for nightly builds such as `2341805`
+      - a path to a directory with the Haxe installation
+  **/
   var version(default, null):String;
+
+  /**
+    In what manner libraries should be resolved.
+  **/
   var resolveLibs(default, null):LibResolution;
 }

--- a/src/haxeshim/LibResolution.hx
+++ b/src/haxeshim/LibResolution.hx
@@ -3,15 +3,31 @@ package haxeshim;
 using tink.CoreApi;
 
 @:enum abstract LibResolution(String) to String {
+  /**
+    Any parameters that are passed to haxeshim are parsed, including hxmls and the `-lib` parameters are "intercepted".
+    To resolve these, we look for a `haxe_libraries/<libName>.hxml` and parse the parameters therein.
+    If they are `-lib` parameters we process them accordingly.
+    Note that in this case, specifying library versions as with `-lib name:version` is not allowed.
+  **/
   var Scoped = 'scoped';
-  var Mixed = 'mixed';
+
+  /**
+    Parameters are still parsed and then passed to `haxelib path` for resolution.
+    In this case `-lib name:version` syntax is allowed.
+  **/
   var Haxelib = 'haxelib';
+
+  /**
+    This is a mix of both approaches. Libraries that are not found using scoped
+    resolutio nor that use `-lib name:version` format are process with `haxelib path`.
+  **/
+  var Mixed = 'mixed';
 
   static public function parse(s:String)
     return switch s {
       case 'scoped': Success(Scoped);
-      case 'mixed': Success(Mixed);
       case 'haxelib': Success(Haxelib);
+      case 'mixed': Success(Mixed);
       default: Failure(new Error(UnprocessableEntity, 'Invalid lib resolution strategy `$s`'));
     }
 }


### PR DESCRIPTION
This allows auto-generating JSON schemas for VSCode with json2object.. well in theory anyway, I ran into a few issues and had to make some manual adjustments. Anyway, the end result is nice:

![](https://i.imgur.com/GxHW0Ut.png)

![](https://i.imgur.com/uF38OtK.png)

In theory it might be appropriate for `version` to become an enum abstract as well for the "constants".