### PR TITLE
Fix haxeshim failing to build some projects in server mode

### DIFF
--- a/src/haxeshim/CompilerServer.hx
+++ b/src/haxeshim/CompilerServer.hx
@@ -132,7 +132,7 @@ class CompilerServer {
         case Failure(e): 
           Exec.die(e.code, e.message);
         case Success(args):
-          var first = Buffer.from(HaxeCli.checkClassPaths(args).join('\n'));
+          var first = Buffer.from(args.join('\n'));
           child.stdin.write(frame(Buffer.concat([first, postfix])));
       }
 


### PR DESCRIPTION
This check causes build failures with some nested project setups such as vshaxe (where the language server fails to build), because the cwd of the `--connect` haxeshim is different from one that `--wait`s. As mentioned, I'm not sure there's any point to checking this on the server end anyway as the client will already have done so.